### PR TITLE
fix: correçãso de registro de logs de agendamento como informação

### DIFF
--- a/src/rn/ProtocoloIntegradoAgendamentoRN.php
+++ b/src/rn/ProtocoloIntegradoAgendamentoRN.php
@@ -38,7 +38,7 @@ class ProtocoloIntegradoAgendamentoRN extends InfraRN {
             InfraDebug::getInstance()->gravar('TEMPO TOTAL DE EXECUCAO: '.$numSeg.' s');
             InfraDebug::getInstance()->gravar('FIM');
             
-            LogSEI::getInstance()->gravar(InfraDebug::getInstance()->getStrDebug());
+            LogSEI::getInstance()->gravar(InfraDebug::getInstance()->getStrDebug(), InfraLog::$INFORMACAO);
             InfraDebug::getInstance()->limpar();
 		  
         } catch(Exception $e) {
@@ -71,7 +71,7 @@ class ProtocoloIntegradoAgendamentoRN extends InfraRN {
             $numSeg = InfraUtil::verificarTempoProcessamento($numSeg);
             InfraDebug::getInstance()->gravar('TEMPO TOTAL DE EXECUCAO: '.$numSeg.' s');
             InfraDebug::getInstance()->gravar('FIM');
-            LogSEI::getInstance()->gravar(InfraDebug::getInstance()->getStrDebug());
+            LogSEI::getInstance()->gravar(InfraDebug::getInstance()->getStrDebug(), InfraLog::$INFORMACAO);
             InfraDebug::getInstance()->limpar();
         
         } catch(Exception $e) {
@@ -106,7 +106,7 @@ class ProtocoloIntegradoAgendamentoRN extends InfraRN {
             InfraDebug::getInstance()->gravar('TEMPO TOTAL DE EXECUCAO: '.$numSeg.' s');
             InfraDebug::getInstance()->gravar('FIM');
             
-            LogSEI::getInstance()->gravar(InfraDebug::getInstance()->getStrDebug());
+            LogSEI::getInstance()->gravar(InfraDebug::getInstance()->getStrDebug(), InfraLog::$INFORMACAO);
             InfraDebug::getInstance()->limpar();
         
         } catch(Exception $e) {


### PR DESCRIPTION
Necessário devido a todos os logs de agendamento de tarefas estearem sendo registrados como erro no SEI.